### PR TITLE
Fix recursion bug causing N+1 calls

### DIFF
--- a/src/tasmotapm/usr/local/emhttp/plugins/tasmotapm/statusmove.page
+++ b/src/tasmotapm/usr/local/emhttp/plugins/tasmotapm/statusmove.page
@@ -38,7 +38,7 @@ $mytiles[$pluginname]['column1'] =
             </tr>
 
             <tr class="tasmotapm_view">
-            <td><span class="w26">Yesterday:</span><span class="w26 tasmotapm-energy-yesterday"></span> 
+            <td><span class="w26">Yesterday:</span><span class="w26 tasmotapm-energy-yesterday"></span>
             <span class="w26 tasmotapm-costs_yesterday"></span> </td>
             </tr>
 
@@ -48,36 +48,36 @@ $mytiles[$pluginname]['column1'] =
                 <span class="w26 tasmotapm-costs_total"></span></span></td>
             </tr>
 
-            <tr class="tasmotapm_view">     
+            <tr class="tasmotapm_view">
                 <td><span class="w26">Power</span>
                 <span class="w26 tasmotapm-energy-power"></span></td>
             </tr>
             <tr class="tasmotapm_view">
-              
+
                 <td><span class="w26">Voltage</span>
                 <span class="w26 tasmotapm-energy-voltage"></span></td>
-               
+
             </tr>
             <tr class="tasmotapm_view">
-             
+
                 <td><span class="w26">Current</span>
             <span class="w26 tasmotapm-energy-current"></span></td>
-           
+
             </tr>
             <tr class="tasmotapm_view">
             <td><span class="w26">Apparent power</span>
             <span class="w26 tasmotapm-energy-apparentpower"></span></td>
-       
+
             </tr>
             <tr class="tasmotapm_view">
          <td><span class="w26">Reactive power</span>
             <span class="w26 tasmotapm-energy-reactivepower"></span></td>
-  
+
             </tr>
             <tr class="tasmotapm_view">
               <td><span class="w26">Efficiency</span>
                 <span class="w26 tasmotapm-energy-efficiency"></span></td>
-          
+
             </tr>
 </tbody>
 EOT;
@@ -105,9 +105,10 @@ function tasmotapm_status() {
     });
 }
 
-$(function(){
-  tasmotapm_status();
-});
-
+if (<?=$tasmotapm_cfg['UIREFRESH'];?>) {
+    setInterval(tasmotapm_status, <?=$tasmotapm_cfg['UIREFRESH'];?>);
+} else {
+    tasmotapm_status();
+}
 
 </script>

--- a/src/tasmotapm/usr/local/emhttp/plugins/tasmotapm/statusmove.page
+++ b/src/tasmotapm/usr/local/emhttp/plugins/tasmotapm/statusmove.page
@@ -105,10 +105,12 @@ function tasmotapm_status() {
     });
 }
 
+$(function(){
+  tasmotapm_status();
+});
+
 if (<?=$tasmotapm_cfg['UIREFRESH'];?>) {
-    setInterval(tasmotapm_status, <?=$tasmotapm_cfg['UIREFRESH'];?>);
-} else {
-    tasmotapm_status();
+  setInterval(tasmotapm_status, <?=$tasmotapm_cfg['UIREFRESH'];?>);
 }
 
 </script>


### PR DESCRIPTION
Fix recursion bug causing N+1 calls, which could lead to tab/browser/tasmota device crashing if the page is left open.

---

Originally reported here: https://forums.unraid.net/topic/104565-plugin-tasmota-power-monitor/?do=findComment&comment=1272440

Found the problem, it is indeed recursion:

https://github.com/SimonFair/tasmotapm-unraid/commit/42d19aa714319843114c626059dd9c5fae094a90#diff-ffc2f4755a67ff8df0cc721d1c185eee2502fd60ec1193caf6b36ecb34f1b9dbR106

The setInterval call needs to be at the page level as its a repeat call not a delayed call, as at the moment its nested within the tasmotapm_status() method, meaning each time its calling itself N+1 times.

The fix should be to move the setInterval call outside of the method. You can replace the page load call to start itself with the setInterval code.